### PR TITLE
RE: fix: HttpRequestParser to read header value properly

### DIFF
--- a/srcs/server/http_request_parser.cpp
+++ b/srcs/server/http_request_parser.cpp
@@ -16,7 +16,7 @@ std::string HttpRequestParser::GetUri(const std::string& recv_msg) {
 std::string HttpRequestParser::GetProtocolVersion(const std::string& recv_msg) {
   int start_pos = recv_msg.find(' ');
   start_pos = recv_msg.find(' ', start_pos + 1);
-  int end_pos = recv_msg.find('\r', start_pos + 1);
+  int end_pos = recv_msg.find("\r\n", start_pos + 1);
   std::string version(recv_msg.begin() + start_pos + 1,
                       recv_msg.begin() + end_pos);
   return version;
@@ -34,7 +34,7 @@ std::string HttpRequestParser::GetFieldValue(const char* field_name,
   int name_start_pos = recv_msg.find(field_name, 0, strlen(field_name));
   if (-1 == name_start_pos) return "";
   int value_start_pos = recv_msg.find(": ", name_start_pos + 1) + 2;
-  int value_end_pos = recv_msg.find('\r', value_start_pos + 1);
+  int value_end_pos = recv_msg.find("\r\n", value_start_pos + 1);
   std::string value(recv_msg.begin() + value_start_pos,
                     recv_msg.begin() + value_end_pos);
   return value;

--- a/srcs/server/http_request_parser.cpp
+++ b/srcs/server/http_request_parser.cpp
@@ -16,7 +16,7 @@ std::string HttpRequestParser::GetUri(const std::string& recv_msg) {
 std::string HttpRequestParser::GetProtocolVersion(const std::string& recv_msg) {
   int start_pos = recv_msg.find(' ');
   start_pos = recv_msg.find(' ', start_pos + 1);
-  int end_pos = recv_msg.find('\n', start_pos + 1);
+  int end_pos = recv_msg.find('\r', start_pos + 1);
   std::string version(recv_msg.begin() + start_pos + 1,
                       recv_msg.begin() + end_pos);
   return version;
@@ -34,7 +34,7 @@ std::string HttpRequestParser::GetFieldValue(const char* field_name,
   int name_start_pos = recv_msg.find(field_name, 0, strlen(field_name));
   if (-1 == name_start_pos) return "";
   int value_start_pos = recv_msg.find(": ", name_start_pos + 1) + 2;
-  int value_end_pos = recv_msg.find('\n', value_start_pos + 1);
+  int value_end_pos = recv_msg.find('\r', value_start_pos + 1);
   std::string value(recv_msg.begin() + value_start_pos,
                     recv_msg.begin() + value_end_pos);
   return value;


### PR DESCRIPTION
# 概要
※先程一度お送りしたプルリクを微修正しました。
HttpRequestParserの中のリクエストヘッダー読み込み部分を修正しました。
元々は`\n`の手前まで読み込むという実装になっていましたが、ヘッダーは`\r\n`で改行されるため、`\r\n`の手前まで読み込む、という実装が正しいかと思います。

# 受入条件
内容確認、動作確認

# 備考
この修正によって、fyutaさんから指摘頂いていた、404エラーになってしまう、という問題も解決されるかと思います。