### PR TITLE
update: HttpResponseでのRequest,ServerConfigの持ち方を参照に変更

### DIFF
--- a/srcs/response/http_response.cpp
+++ b/srcs/response/http_response.cpp
@@ -9,8 +9,8 @@ const std::string HttpResponse::kStatusDescMethodNotAllowed = "405 Not Allowed";
 const std::string HttpResponse::kStatusDescVersionNotSupported =
     "505 HTTP Version Not Supported";
 
-HttpResponse::HttpResponse(const HttpRequest &http_request,
-                           const ServerConfig &server_config)
+HttpResponse::HttpResponse(HttpRequest &http_request,
+                           ServerConfig &server_config)
     : http_request_(http_request),
       server_config_(server_config),
       status_code_(kStatusCodeOK),

--- a/srcs/response/http_response.hpp
+++ b/srcs/response/http_response.hpp
@@ -3,18 +3,18 @@
 
 #include <dirent.h>    // for opendir, readdir
 #include <sys/stat.h>  // for stat
+#include <sys/wait.h>
 #include <unistd.h>
 
 #include <algorithm>  // for sort
 #include <cctype>     // for isdigit
 #include <ctime>
 #include <fstream>
+#include <iomanip>
 #include <iostream>
 #include <sstream>
 #include <string>
 #include <vector>
-#include <sys/wait.h>
-#include <iomanip>
 
 #include "http_request.hpp"
 #include "server_config.hpp"
@@ -22,8 +22,7 @@
 class HttpResponse {
  public:
   // Constructor
-  HttpResponse(const HttpRequest &http_request,
-               const ServerConfig &server_config);
+  HttpResponse(HttpRequest &http_request, ServerConfig &server_config);
 
   // Destructor
   virtual ~HttpResponse();
@@ -81,8 +80,8 @@ class HttpResponse {
   std::string CreateFileList(std::vector< std::string >);
 
   // Data members
-  HttpRequest http_request_;
-  ServerConfig server_config_;
+  HttpRequest &http_request_;
+  ServerConfig &server_config_;
   int status_code_;
   std::string status_desc_;
   bool is_bad_request_;


### PR DESCRIPTION
結合テストの際、HttpResponseのデストラクタでダブルフリーで落ちていた。
ServerConfigのコピーが浅いコピーとなっていた可能性がある。
本来は領域の解放責務はConfigクラスにあるため、HttpResponseでは参照として持たせ、
解放が不要となるように改修した。