### PR TITLE
update: レスポンスへ渡すHttpRequest,ServerConfigにconstをつける

### DIFF
--- a/srcs/config/server_config.cpp
+++ b/srcs/config/server_config.cpp
@@ -29,11 +29,12 @@ ServerConfig &ServerConfig::operator=(ServerConfig const &rhs) {
 }
 
 void ServerConfig::ParseListen(
-    const std::vector<std::pair<int, std::string> > &list) {
+    const std::vector< std::pair< int, std::string > > &list) {
   std::string::size_type delim_pos;
 
   if (list.size() != 2) {
-    ParserUtils::MakeUnexpected("invalid number of args in listen directive", list[0].first);
+    ParserUtils::MakeUnexpected("invalid number of args in listen directive",
+                                list[0].first);
   }
   std::string set_value = list[1].second;
   delim_pos = set_value.find(':');
@@ -46,15 +47,18 @@ void ServerConfig::ParseListen(
 }
 
 // return locationConfig whose location_path_'s length is longest.
-LocationConfig *ServerConfig::SelectLocationConfig(const std::string &uri) {
-  LocationConfig *selected = &default_location_config_;
+const LocationConfig *ServerConfig::SelectLocationConfig(
+    const std::string &uri) const {
+  const LocationConfig *selected = &default_location_config_;
 
-  for (std::vector<LocationConfig>::iterator it = vec_location_config_.begin();
+  for (std::vector< LocationConfig >::const_iterator it =
+           vec_location_config_.begin();
        it != vec_location_config_.end(); ++it) {
     if (uri.find(it->location_path_) == 0) {
       if (selected == &default_location_config_) {
         selected = it.base();
-      } else if (selected->location_path_.length() < it->location_path_.length()){
+      } else if (selected->location_path_.length() <
+                 it->location_path_.length()) {
         selected = it.base();
       }
     }
@@ -62,10 +66,10 @@ LocationConfig *ServerConfig::SelectLocationConfig(const std::string &uri) {
   return (selected);
 }
 
-std::string ServerConfig::UpdateUri(std::string uri) {
+std::string ServerConfig::UpdateUri(std::string uri) const {
   std::string path;
 
-  LocationConfig *lc = SelectLocationConfig(uri);
+  const LocationConfig *lc = SelectLocationConfig(uri);
   if (lc == NULL) {
     return ("");
   }
@@ -80,7 +84,8 @@ std::string ServerConfig::UpdateUri(std::string uri) {
 
   struct stat buffer;
   if (*(path.end() - 1) == '/') {
-    for (std::vector<std::string>::iterator it = lc->vec_index_.begin(); it != lc->vec_index_.end(); ++it) {
+    for (std::vector< std::string >::const_iterator it = lc->vec_index_.begin();
+         it != lc->vec_index_.end(); ++it) {
       if (stat((path + *it).c_str(), &buffer) == 0) {
         return (path + *it);
       }
@@ -89,13 +94,12 @@ std::string ServerConfig::UpdateUri(std::string uri) {
   return (path);
 }
 
-
 void ServerConfig::PrintVal() {
   std::cout << "=====" << std::endl;
   std::cout << "listen " << host_ << ":" << port_ << std::endl;
 
   std::cout << "server_name ";
-  for (std::vector<std::string>::iterator it = vec_server_names_.begin();
+  for (std::vector< std::string >::iterator it = vec_server_names_.begin();
        it != vec_server_names_.end(); ++it) {
     std::cout << *it << " ";
   }
@@ -105,7 +109,8 @@ void ServerConfig::PrintVal() {
 
   std::cout << "client_max_body_size " << client_max_body_size_ << std::endl;
 
-  for (std::vector<LocationConfig>::iterator it = vec_location_config_.begin();
+  for (std::vector< LocationConfig >::iterator it =
+           vec_location_config_.begin();
        it != vec_location_config_.end(); ++it) {
     std::cout << "\n[location]" << std::endl;
     it->PrintVal();

--- a/srcs/config/server_config.hpp
+++ b/srcs/config/server_config.hpp
@@ -1,13 +1,14 @@
 #ifndef SERVER_CONFIG_HPP_
-# define SERVER_CONFIG_HPP_
+#define SERVER_CONFIG_HPP_
 
-#include <set>
-#include <string>
-#include <vector>
+#include <sys/stat.h>
+
 #include <algorithm>
 #include <iostream>
+#include <set>
 #include <sstream>
-#include <sys/stat.h>
+#include <string>
+#include <vector>
 
 #include "location_config.hpp"
 #include "parser_utils.hpp"
@@ -21,20 +22,21 @@ class ServerConfig {
   ServerConfig &operator=(const ServerConfig &rhs);
 
   // URIとlocation_path_の前方一致で一番長いものを返す、見つからない場合はNULLは返さず、defaultの値が使われることにする。
-  LocationConfig* SelectLocationConfig(const std::string& uri);
+  const LocationConfig *SelectLocationConfig(const std::string &uri) const;
   // テスト参照、返したパスにファイルが存在するかどうかは別で確認の必要があり。
-  std::string UpdateUri(std::string uri);
+  std::string UpdateUri(std::string uri) const;
   void PrintVal();
   // other configs are parsed by config utils
-  void ParseListen(const std::vector<std::pair<int, std::string> > &list);
+  void ParseListen(const std::vector< std::pair< int, std::string > > &list);
 
   size_t port_;
   std::string host_;
-  std::vector<std::string> vec_server_names_;
+  std::vector< std::string > vec_server_names_;
   std::string error_page_path_;
   size_t client_max_body_size_;
-  std::vector<LocationConfig> vec_location_config_;
+  std::vector< LocationConfig > vec_location_config_;
   LocationConfig default_location_config_;
+
  private:
   void Init();
 };

--- a/srcs/response/http_response.cpp
+++ b/srcs/response/http_response.cpp
@@ -9,8 +9,8 @@ const std::string HttpResponse::kStatusDescMethodNotAllowed = "405 Not Allowed";
 const std::string HttpResponse::kStatusDescVersionNotSupported =
     "505 HTTP Version Not Supported";
 
-HttpResponse::HttpResponse(HttpRequest &http_request,
-                           ServerConfig &server_config)
+HttpResponse::HttpResponse(const HttpRequest &http_request,
+                           const ServerConfig &server_config)
     : http_request_(http_request),
       server_config_(server_config),
       status_code_(kStatusCodeOK),
@@ -28,9 +28,9 @@ bool HttpResponse::IsCgiFileExtension(const std::string &file_type) const {
   if (!location_config_) {
     return false;
   }
-  std::vector< std::string >::iterator first =
+  std::vector< std::string >::const_iterator first =
       location_config_->vec_cgi_file_extension_.begin();
-  std::vector< std::string >::iterator last =
+  std::vector< std::string >::const_iterator last =
       location_config_->vec_cgi_file_extension_.end();
   if (std::find(first, last, file_type) == last) {
     return false;
@@ -333,7 +333,7 @@ void HttpResponse::MakeBody200() {
 }
 
 bool HttpResponse::IsAllowedMethod() const {
-  std::vector< std::string >::iterator it, first, last;
+  std::vector< std::string >::const_iterator it, first, last;
   if (!location_config_) {
     return false;
   }
@@ -358,8 +358,8 @@ bool HttpResponse::IsDigitSafe(char ch) {
 }
 
 void HttpResponse::ValidateVersion() {
-  std::string::iterator it = http_request_.version_.begin();
-  std::string::iterator end = http_request_.version_.end();
+  std::string::const_iterator it = http_request_.version_.begin();
+  std::string::const_iterator end = http_request_.version_.end();
   if (*it != '1') {
     is_supported_version_ = false;
     return;

--- a/srcs/response/http_response.hpp
+++ b/srcs/response/http_response.hpp
@@ -22,7 +22,8 @@
 class HttpResponse {
  public:
   // Constructor
-  HttpResponse(HttpRequest &http_request, ServerConfig &server_config);
+  HttpResponse(const HttpRequest &http_request,
+               const ServerConfig &server_config);
 
   // Destructor
   virtual ~HttpResponse();
@@ -80,14 +81,14 @@ class HttpResponse {
   std::string CreateFileList(std::vector< std::string >);
 
   // Data members
-  HttpRequest &http_request_;
-  ServerConfig &server_config_;
+  const HttpRequest &http_request_;
+  const ServerConfig &server_config_;
   int status_code_;
   std::string status_desc_;
   bool is_bad_request_;
   bool is_supported_version_;
   std::string content_type_;
-  LocationConfig *location_config_;
+  const LocationConfig *location_config_;
   std::string requested_file_path_;
   std::ifstream requested_file_;
   bool is_file_exists_;


### PR DESCRIPTION
昨日話題に上がった、HttpResponseへ渡す情報にconstつける作業を実施しました。
機能的な変更はありません。confs/test.conf にて、index.html が正常に表示されることを確認済みです。

！！！注意！！！
私のオートフォーマット機能で、修正していない箇所もフォーマット変更が入り差分が多く見えてしまっています。
基本的には、
・HttpResponseのServerConfig, HttpRequest に関するメンバ変数 にconstをつける
・関連するConfigの関数にconfigをつける
・iterator->const_iterator に変更
のみの修正になります。
確認しづらくなってすみません。

[背景]
HttpResponseでは受け取った情報を参照する目的のため、謝って書き換えないようにconstをつける。関連する呼び出す関数側もconstをつけるなど対応を行なった。