### PR TITLE
temporary fix: fix ReadMessage to properly read POST requests

### DIFF
--- a/srcs/server/server.cpp
+++ b/srcs/server/server.cpp
@@ -148,27 +148,31 @@ std::string Server::ReadMessage(int *p_fd) {
   memset(buf, 0, sizeof(buf));
   ssize_t read_size = 0;
 
-  do {  //バッファサイズの制限は嫌なので、無制限に読み込めるようにしたい
-    read_size = recv(*p_fd, buf, sizeof(buf) - 1, 0);
-    if (read_size == -1) {
-      std::cout << "read() failed." << std::endl;
-      std::cout << "ERROR: " << errno << std::endl;
-      close(*p_fd);
-      *p_fd = -1;
-      break;
-    }
-    if (read_size > 0) {
-      recv_str.append(buf);
-      memset(buf, 0, sizeof(buf));
-    }
-    //読み込んだ最後が\r\n\r\nなら終了。
-    if ((recv_str[recv_str.length() - 4] == 0x0d) &&
-        (recv_str[recv_str.length() - 3] == 0x0a) &&
-        (recv_str[recv_str.length() - 2] == 0x0d) &&
-        (recv_str[recv_str.length() - 1] == 0x0a)) {
-      break;
-    }
-  } while (read_size > 0);
+  // do {  //バッファサイズの制限は嫌なので、無制限に読み込めるようにしたい
+  read_size = recv(*p_fd, buf, sizeof(buf) - 1, 0);
+  if (read_size == -1) {
+    std::cout << "recv() failed." << std::endl;
+    std::cout << "ERROR: " << strerror(errno) << std::endl;
+    close(*p_fd);
+    *p_fd = -1;
+    // break;
+    exit(1);
+  }
+  if (read_size > 0) {
+    std::string buf_string(buf, read_size);
+    recv_str.append(buf_string);
+    memset(buf, 0, sizeof(buf));
+  }
+  // 読み込んだ最後が\r\n\r\nなら終了。
+  // if ((recv_str[recv_str.length() - 4] == 0x0d) &&
+  //     (recv_str[recv_str.length() - 3] == 0x0a) &&
+  //     (recv_str[recv_str.length() - 2] == 0x0d) &&
+  //     (recv_str[recv_str.length() - 1] == 0x0a)) {
+  //   break;
+  // } else if (recv_str[recv_str.length() - 1] == '-' &&
+  //            recv_str[recv_str.length() - 2] == '-')
+  //   break;
+  // } while (read_size > 0);
   return recv_str;
 }
 
@@ -227,7 +231,7 @@ void Server::Run() {
         std::string server_response = response.GetResponse();
         if (send(it->fd_, server_response.c_str(), server_response.length(),
                  0) == -1) {
-          std::cout << "write() failed." << std::endl;
+          std::cout << "send() failed." << std::endl;
         }
         /***
          * fdを切断

--- a/srcs/server/server.hpp
+++ b/srcs/server/server.hpp
@@ -9,7 +9,7 @@
 
 class Server {
  private:
-  static const int kReadBufferSize = 1024;
+  static const int kReadBufferSize = 10000;
   static const int kMaxSessionNum = 10;
 
   Config config_;


### PR DESCRIPTION
# 概要
POSTリクエストを正常に読み込むための暫定的なReadMessage関数の修正です。

# 受入条件
下記の手順で動作確認をお願いします。
1. `make`
2. `./webserv confs/upload_test.conf`
3. http://localhost:8080/index-upload.html にアクセスして、画像をアップロード
4. アップロードした画像が`./www/upload/`に保存されているか確認

# 備考
- あくまで暫定的な修正になります。一回のrecvで読み切るために、`kReadBufferSize`を10000まで引き上げています。
- 巨大な画像をアップロードすると読みきれない可能性があるので、小さめの画像で試してみてください。
- 本来はrecvで読み込んだ文字列を`\r\n`ごとにパースし、`Content-Length`の値をチェックして、その長さ分、Request bodyを読み込んだかをチェックする必要があるかと思います。
- server.cpp:162-163の修正は、request bodyでバイナリーデータが送られて来た場合に、char*に読み込まれたデータをstringにするために必要な処理になります。