### PR TITLE
fix UpdateUri to properly handle requests with URIs pointed at directories

### DIFF
--- a/srcs/config/server_config.cpp
+++ b/srcs/config/server_config.cpp
@@ -75,11 +75,12 @@ std::string ServerConfig::UpdateUri(std::string uri) const {
 
   // if there is no extension and uri does not end with '/', uri = uri + "/".
   // [TODO]
-  size_t file_name_pos = uri.find_last_of("/");
-  if (uri.find_last_of(".", uri.length() - file_name_pos) == std::string::npos &&
-      *(path.end() - 1) != '/') {
-    uri += "/";
-  }
+  // size_t file_name_pos = uri.find_last_of("/");
+  // if (uri.find_last_of(".", uri.length() - file_name_pos) ==
+  // std::string::npos &&
+  //     *(path.end() - 1) != '/') {
+  //   uri += "/";
+  // }
 
   const LocationConfig *lc = SelectLocationConfig(uri);
   std::string root;


### PR DESCRIPTION
# 概要
server_config.cppの中のUpdateUriにおいて、末尾に`/`を追加する部分をコメントアウトしました。

# 受入条件
内容確認、動作確認

# 備考
この部分はhttp://localhost:8080/directory_name のようなURLでアクセスされた場合に、URIを`/diretory_name`から`/directory_name/`に修正するために実装されているかと思うのですが、この処理は途中で301レスポンスによる転送も含まれてくるので、HttpResponseクラスで実装させて頂いたほうがよいかと思っています。