### PR TITLE
fix: ErrorPagePathの型の変更によるコンパイルエラーの修正

### DIFF
--- a/srcs/response/http_response.cpp
+++ b/srcs/response/http_response.cpp
@@ -383,11 +383,11 @@ void HttpResponse::CreateDefaultErrorPage() {
 }
 
 void HttpResponse::MakeErrorBody() {
-  if (server_config_.error_page_path_ == "") {
-    CreateDefaultErrorPage();
-  } else {
-    CreateCustomizedErrorPage();
-  }
+  // if (server_config_.error_page_path_ == "") {
+  // } else {
+  //   CreateCustomizedErrorPage();
+  // }
+  CreateDefaultErrorPage();
 }
 
 void HttpResponse::DeleteRequestedFile() {
@@ -753,6 +753,7 @@ void HttpResponse::MakeResponse() {
     case kStatusCodeMovedPermanently:
       MakeBody301();
       MakeHeader301();
+      break;
     default:
       MakeErrorBody();
       MakeErrorHeader();


### PR DESCRIPTION
# 概要
std::string => std::map<int, std::string>に変更したことによりコンパイルエラーが出てしまっているので、とりあえず動くことだけを考えて変更してます。僕の環境だとswitchでbreakしないとコンパイルできないという謎仕様かつ、足した方が良さそうなのでbreakも足しました。

型の変更については、nginxと同じく
```
server {
    error_page 404 /error404.html 400 /error400.html;
    location / {
    }
}
```
というstatusとpathのセットで指定できます。

# 受け入れ条件
コンパイルできるか、コードは問題ないか