### PR TITLE
クライアント情報をレスポンスに渡すようにする

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ OBJSDIR		:= objs/
 
 SRCS	:= main.cpp \
 		server/server.cpp \
+		server/client_socket.cpp \
 		server/server_socket.cpp \
 		server/http_request_parser.cpp \
 		response/http_response.cpp \

--- a/srcs/response/http_response.cpp
+++ b/srcs/response/http_response.cpp
@@ -19,9 +19,11 @@ const std::map< std::string, std::string > HttpResponse::kMimeTypeMap =
     HttpResponse::CreateMimeTypeMap();
 
 HttpResponse::HttpResponse(const HttpRequest &http_request,
-                           const ServerConfig &server_config)
+                           const ServerConfig &server_config,
+                           const t_client_info &client_info)
     : http_request_(http_request),
       server_config_(server_config),
+      client_info_(client_info),
       status_code_(kStatusCodeOK),
       status_desc_(kStatusDescOK),
       is_bad_request_(http_request_.is_bad_request_),

--- a/srcs/response/http_response.hpp
+++ b/srcs/response/http_response.hpp
@@ -18,6 +18,7 @@
 #include <string>
 #include <vector>
 
+#include "client_info.hpp"
 #include "http_request.hpp"
 #include "server_config.hpp"
 
@@ -25,7 +26,8 @@ class HttpResponse {
  public:
   // Constructor
   HttpResponse(const HttpRequest &http_request,
-               const ServerConfig &server_config);
+               const ServerConfig &server_config,
+               const t_client_info &client_info);
 
   // Destructor
   virtual ~HttpResponse();
@@ -113,6 +115,7 @@ class HttpResponse {
   // Data members
   const HttpRequest &http_request_;
   const ServerConfig &server_config_;
+  const t_client_info &client_info_;
   int status_code_;
   std::string status_desc_;
   bool is_bad_request_;

--- a/srcs/server/Makefile
+++ b/srcs/server/Makefile
@@ -1,5 +1,6 @@
 SRCS	= main.cpp \
 		server.cpp \
+		client_socket.cpp \
 		server_socket.cpp \
 		http_request_parser.cpp
 

--- a/srcs/server/client_info.hpp
+++ b/srcs/server/client_info.hpp
@@ -1,0 +1,12 @@
+#ifndef CLIENT_INFO_HPP
+#define CLIENT_INFO_HPP
+
+#include <string>
+
+typedef struct s_client_info {
+  std::string hostname;
+  std::string ipaddr;
+  int port;
+} t_client_info;
+
+#endif

--- a/srcs/server/client_socket.cpp
+++ b/srcs/server/client_socket.cpp
@@ -1,0 +1,45 @@
+#include "client_socket.hpp"
+
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <sys/socket.h>
+
+#include <iostream>
+
+ClientSocket::ClientSocket(int fd, const ServerSocket *parent)
+    : fd_(fd), parent_(parent) {
+  struct sockaddr_in sin;
+  socklen_t len = sizeof(sin);
+
+  if (-1 == getpeername(fd, (struct sockaddr *)&sin, &len)) {
+    std::cout << "ERROR getpeername fail!!!" << std::endl;
+    return;
+  }
+  struct hostent *peer_host;
+  if (!(peer_host = gethostbyaddr((char *)&sin.sin_addr.s_addr,
+                                  sizeof(sin.sin_addr), AF_INET))) {
+    std::cout << "peer_host is null" << std::endl;
+    return;
+  }
+  info_.hostname.assign(peer_host->h_name);
+  info_.ipaddr.assign(inet_ntoa(sin.sin_addr));
+  info_.port = ntohs(sin.sin_port);
+
+  std::cout << "接続: " << info_.hostname << "(" << info_.ipaddr << ")ポート "
+            << info_.port << " ディスクリプタ " << fd << " 番\n ";
+}
+
+ClientSocket::ClientSocket(const ClientSocket &other) { *this = other; }
+
+ClientSocket &ClientSocket::operator=(const ClientSocket &other) {
+  fd_ = other.fd_;
+  parent_ = other.parent_;
+  info_ = other.info_;
+  last_access_ = other.last_access_;
+  return *this;
+}
+
+void ClientSocket::Init() {
+  SetNonBlocking(fd_);
+  time(&last_access_);
+}

--- a/srcs/server/client_socket.hpp
+++ b/srcs/server/client_socket.hpp
@@ -1,15 +1,21 @@
 #ifndef CLIENT_SOCKET_HPP
 #define CLIENT_SOCKET_HPP
 
+#include "client_info.hpp"
 #include "server_socket.hpp"
 
 class ClientSocket {
  public:
   int fd_;
-  const ServerSocket* parent_;
-  ClientSocket(int fd, const ServerSocket* parent) : fd_(fd), parent_(parent) {
-    SetNonBlocking(fd);
-  }
+  const ServerSocket *parent_;
+  t_client_info info_;
+  time_t last_access_;
+  ClientSocket(int fd, const ServerSocket *parent);
+  ClientSocket(const ClientSocket &other);
+  ~ClientSocket() {}
+  ClientSocket &operator=(const ClientSocket &other);
+
+  void Init();
 };
 
 #endif

--- a/srcs/server/stub/http_response.hpp
+++ b/srcs/server/stub/http_response.hpp
@@ -3,6 +3,7 @@
 
 #include <string>
 
+#include "client_info.hpp"
 #include "config.hpp"
 #include "http_request.hpp"
 
@@ -11,11 +12,12 @@ class HttpResponse {
   HttpResponse();
   const HttpRequest &request_;
   const ServerConfig &sc_;
+  const t_client_info &info_;
 
  public:
   HttpResponse(const HttpRequest &http_request,
-               const ServerConfig &server_config)
-      : request_(http_request), sc_(server_config) {}
+               const ServerConfig &server_config, const t_client_info &info)
+      : request_(http_request), sc_(server_config), info_(info) {}
   ~HttpResponse() {}
 
   std::string GetResponse() {


### PR DESCRIPTION
デバッグ用に取得していたクライアント情報をHttpResponseクラスに渡すようにした

## 概要
ホスト名、IP、ポートなどをまとめてt_client_info構造体にまとめて
HttpResponseクラスのコンストラクタまで渡しています。

## 受け入れ条件
HttpResponse側で、正しく情報取得ができているかご確認をお願いします。

Close #20 