### PR TITLE
push backの際に、領域の再確保によって元々あったデータが飛ぶ

### DIFF
--- a/srcs/server/http_request_parser.hpp
+++ b/srcs/server/http_request_parser.hpp
@@ -4,6 +4,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <utility>
+#include <vector>
 
 #include "http_request.hpp"
 

--- a/srcs/server/server.cpp
+++ b/srcs/server/server.cpp
@@ -43,6 +43,7 @@ Server::Server(const char *conf) : config_(conf) {
 
 void Server::CreateServerSockets() {
   std::vector< ServerConfig >::iterator it = config_.vec_server_config_.begin();
+  sockets_.reserve(config_.vec_server_config_.size());
   for (; it != config_.vec_server_config_.end(); ++it) {
     //重複するポートがないかチェック
     std::vector< ServerSocket >::iterator sit = sockets_.begin();

--- a/srcs/server/server.hpp
+++ b/srcs/server/server.hpp
@@ -9,7 +9,7 @@
 
 class Server {
  private:
-  static const int kMaxSessionNum = 10;
+  static const int kMaxSessionNum = 512;
 
   Config config_;
   std::vector< ServerSocket > sockets_;

--- a/srcs/server/server_socket.cpp
+++ b/srcs/server/server_socket.cpp
@@ -21,6 +21,8 @@ ServerSocket::ServerSocket(const ServerSocket &other) { *this = other; }
 ServerSocket &ServerSocket::operator=(const ServerSocket &other) {
   port_ = other.port_;
   host_ = other.host_;
+  listenfd_ = other.listenfd_;
+  serv_addr_ = other.serv_addr_;
   return *this;
 }
 

--- a/srcs/server/server_socket.cpp
+++ b/srcs/server/server_socket.cpp
@@ -21,8 +21,6 @@ ServerSocket::ServerSocket(const ServerSocket &other) { *this = other; }
 ServerSocket &ServerSocket::operator=(const ServerSocket &other) {
   port_ = other.port_;
   host_ = other.host_;
-  listenfd_ = other.listenfd_;
-  serv_addr_ = other.serv_addr_;
   return *this;
 }
 


### PR DESCRIPTION
#include <vector>は環境の問題です。

コピーコンストラクタで全部移し替える実装にしてもいいですが、そうすると謎のエラーに見舞われたので
こっちにしてみました。

