### PR TITLE
modify #24 failed syscall handlings in HttpResponse

### DIFF
--- a/srcs/response/http_response.hpp
+++ b/srcs/response/http_response.hpp
@@ -118,6 +118,7 @@ class HttpResponse {
   std::string ExtractLocationPath(const std::string &header_value);
   std::string GetFieldValue(const std::string &header_field);
   bool CreateCgiBody(bool has_content_length);
+  void Make500Response();
 
   // Helper functions
   std::string ShortenRequestBody(const std::string &);


### PR DESCRIPTION
# 概要
HttpResponseクラス中でシステムコールが失敗した場合に、500エラーで返すように実装を修正
また500エラーに接続を切断するように修正

# 受入条件
内容確認、動作確認

close #24 