### PR TITLE
rewriteが相対パスの時に http://host:port をLocationにつける

### DIFF
--- a/srcs/response/http_response.cpp
+++ b/srcs/response/http_response.cpp
@@ -314,7 +314,14 @@ void HttpResponse::MakeHeaderRedirection() {
         requested_file_path_.substr(location_config_->root_.length());
     oss_location << requested_file_path_short_ << "\r\n";
   } else {
-    oss_location << "Location: " << requested_file_path_ << "\r\n";
+    if (requested_file_path_.find("http://") != 0) {
+      std::map< std::string, std::string >::const_iterator it_host =
+          http_request_.header_fields_.find("Host");
+      oss_location << "Location: http://" << it_host->second;
+    } else {
+      oss_location << "Location: ";
+    }
+    oss_location << requested_file_path_ << "\r\n";
   }
   header_.push_back("HTTP/1.1 ");
   header_.push_back(status_desc_);


### PR DESCRIPTION
# 概要
rewriteが相対パス(Redirect original redirect)で指定されているときには、
**http:host:port**を先頭につけるようにしたかったので
 MakeHeaderRedirectionを変更しました。

# 受け入れ条件
動作もですが、特にコードをここに追加することがいいのかどうかを確認したいです