### PR TITLE
print chr(26); なしでCGIからのリクエストを受け取る。

### DIFF
--- a/srcs/response/http_response.hpp
+++ b/srcs/response/http_response.hpp
@@ -117,7 +117,7 @@ class HttpResponse {
   void SetStatusDescription();
   std::string ExtractLocationPath(const std::string &header_value);
   std::string GetFieldValue(const std::string &header_field);
-  bool CreateCgiBody(bool has_content_length);
+  bool CreateCgiBody(bool has_content_length, bool is_read_finish);
   void Make500Response();
 
   // Helper functions


### PR DESCRIPTION
# 概要

pipeにおいて、書きこみ先のdiscriptorを先に閉じると期待通りにreadが終わるようです。
色々修正してますが、920行目の処理がメインであとはreadの終了判定を色々いじってます

# 受け入れ条件

動作確認、コード確認

「920行目の処理を追加したらうまくいった！！」ということが言いたくて、
別に実装の細かいところを理解しているわけでもないので、マージしていただかなくても大丈夫です
