### PR TITLE
fix #23 to properly handle request connection header

### DIFF
--- a/srcs/response/http_response.cpp
+++ b/srcs/response/http_response.cpp
@@ -302,6 +302,17 @@ void HttpResponse::SetLastModifiedTime(const std::string &path) {
   }
 }
 
+bool HttpResponse::IsRequestConnectionClose() const {
+  std::map< std::string, std::string >::const_iterator it_connection =
+      http_request_.header_fields_.find("Connection");
+  if (it_connection != http_request_.header_fields_.end() &&
+      it_connection->second == "close") {
+    return true;
+  } else {
+    return false;
+  }
+}
+
 void HttpResponse::MakeHeaderRedirection() {
   std::ostringstream oss_content_length, oss_content_type, oss_location;
   oss_content_type << "Content-Type: text/html\r\n";
@@ -327,9 +338,14 @@ void HttpResponse::MakeHeaderRedirection() {
   header_.push_back(oss_content_type.str());
   header_.push_back(oss_content_length.str());
   header_.push_back(oss_location.str());
-  header_.push_back("Connection: keep-alive\r\n");
+  if (IsRequestConnectionClose()) {
+    header_.push_back("Connection: close\r\n");
+    connection_ = kConnectionClose;
+  } else {
+    header_.push_back("Connection: keep-alive\r\n");
+    connection_ = kConnectionKeepAlive;
+  }
   header_.push_back("\r\n");
-  connection_ = kConnectionKeepAlive;
 }
 
 void HttpResponse::MakeErrorHeader() {
@@ -354,7 +370,8 @@ void HttpResponse::MakeErrorHeader() {
   }
   if (status_code_ == kStatusCodeBadRequest ||
       status_code_ == kStatusCodeVersionNotSupported ||
-      status_code_ == kStatusCodeInternalServerError) {
+      status_code_ == kStatusCodeInternalServerError ||
+      IsRequestConnectionClose()) {
     header_.push_back("Connection: close\r\n");
     connection_ = kConnectionClose;
   } else {
@@ -373,9 +390,14 @@ void HttpResponse::MakeHeader204() {
   header_.push_back("\r\n");
   header_.push_back(server_header_);
   header_.push_back(date_header_);
-  header_.push_back("Connection: keep-alive\r\n");
+  if (IsRequestConnectionClose()) {
+    header_.push_back("Connection: close\r\n");
+    connection_ = kConnectionClose;
+  } else {
+    header_.push_back("Connection: keep-alive\r\n");
+    connection_ = kConnectionKeepAlive;
+  }
   header_.push_back("\r\n");
-  connection_ = kConnectionKeepAlive;
 }
 
 void HttpResponse::MakeHeader200() {
@@ -391,11 +413,16 @@ void HttpResponse::MakeHeader200() {
   header_.push_back(oss_content_type.str());
   header_.push_back(oss_content_length.str());
   header_.push_back(oss_last_modified.str());
-  header_.push_back("Connection: keep-alive\r\n");
+  if (IsRequestConnectionClose()) {
+    header_.push_back("Connection: close\r\n");
+    connection_ = kConnectionClose;
+  } else {
+    header_.push_back("Connection: keep-alive\r\n");
+    connection_ = kConnectionKeepAlive;
+  }
   header_.push_back(etag_header_);
   header_.push_back("Accept-Ranges: bytes\r\n");
   header_.push_back("\r\n");
-  connection_ = kConnectionKeepAlive;
 }
 
 void HttpResponse::CreateCgiHeader() {
@@ -407,7 +434,11 @@ void HttpResponse::CreateCgiHeader() {
   header_.insert(header_.begin(), "\r\n");
   header_.insert(header_.begin(), status_desc_);
   header_.insert(header_.begin(), "HTTP/1.1 ");
-  connection_ = kConnectionKeepAlive;
+  if (IsRequestConnectionClose()) {
+    connection_ = kConnectionClose;
+  } else {
+    connection_ = kConnectionKeepAlive;
+  }
 }
 
 void HttpResponse::CreateCustomizedErrorPage(

--- a/srcs/response/http_response.hpp
+++ b/srcs/response/http_response.hpp
@@ -119,6 +119,7 @@ class HttpResponse {
   std::string GetFieldValue(const std::string &header_field);
   bool CreateCgiBody(bool has_content_length, bool is_read_finish);
   void Make500Response();
+  bool IsRequestConnectionClose() const;
 
   // Helper functions
   std::string ShortenRequestBody(const std::string &);


### PR DESCRIPTION
# 概要
#23 に対応するために、HTTPリクエストのConnectionヘッダーの値に応じて、レスポンスのConnetionヘッダーの値を変更するようにしました。

# 受入条件
内容確認、動作確認

# 備考
一応手元でsiegeでのテストを実行したところ、-rが513以上でもちゃんと動いているようでした。

close #23 