### PR TITLE
CGIのタイムアウトとヘッダなしの際の対応

### DIFF
--- a/prep/apache_docker/conf/my-httpd.conf
+++ b/prep/apache_docker/conf/my-httpd.conf
@@ -29,6 +29,8 @@
 # least PidFile.
 #
 ServerRoot "/usr/local/apache2"
+Timeout 5
+
 
 #
 # Mutex: Allows you to set the mutex mechanism and mutex file directory

--- a/srcs/response/http_response.cpp
+++ b/srcs/response/http_response.cpp
@@ -683,6 +683,9 @@ void HttpResponse::SetStatusDescription() {
     case kStatusCodeInternalServerError:
       status_desc_ = kStatusDescInternalServerError;
       break;
+    case kStatusCodeGatewayTimeout:
+      status_desc_ = kStatusDescGatewayTimeout;
+      break;
     case kStatusCodeVersionNotSupported:
       status_desc_ = kStatusDescVersionNotSupported;
       break;

--- a/srcs/response/http_response.cpp
+++ b/srcs/response/http_response.cpp
@@ -943,7 +943,6 @@ void HttpResponse::MakeCgiResponse() {
       return Make500Response();
     }
     if (WIFSIGNALED(wstatus) && WTERMSIG(wstatus) == SIGALRM) {
-      close(pipe_child2parent[WRITE]);
       close(pipe_parent2child[READ]);
       return Make504Response();
     }

--- a/srcs/response/http_response.hpp
+++ b/srcs/response/http_response.hpp
@@ -49,6 +49,7 @@ class HttpResponse {
   static const int kStatusCodeMethodNotAllowed = 405;
   static const int kStatusCodeRequestEntityTooLarge = 413;
   static const int kStatusCodeInternalServerError = 500;
+  static const int kStatusCodeGatewayTimeout = 504;
   static const int kStatusCodeVersionNotSupported = 505;
   static const int kCgiBufferSize = 500;
   static const int kAsciiCodeForEOF = 26;
@@ -65,10 +66,12 @@ class HttpResponse {
   static const std::string kStatusDescMethodNotAllowed;
   static const std::string kStatusDescRequestEntityTooLarge;
   static const std::string kStatusDescInternalServerError;
+  static const std::string kStatusDescGatewayTimeout;
   static const std::string kStatusDescVersionNotSupported;
   static const std::string kConnectionKeepAlive;
   static const std::string kConnectionClose;
   static const std::map< std::string, std::string > kMimeTypeMap;
+  static const unsigned int kCgiTimeout = 60;
 
   // Constructor and assignment operators
   HttpResponse();
@@ -119,6 +122,7 @@ class HttpResponse {
   std::string GetFieldValue(const std::string &header_field);
   bool CreateCgiBody(bool has_content_length, bool is_read_finish);
   void Make500Response();
+  void Make504Response();
 
   // Helper functions
   std::string ShortenRequestBody(const std::string &);


### PR DESCRIPTION
# 概要

* ヘッダなしの場合、ずっと読み込みが終わらない
* 子プロセス側の無限ループの際のwaitpidでのハング
の二つまとめて対応しました。

ヘッダなしの場合の対応がhttp_response.cppの970 ~ 972であとはwaitpidのハング対応です。

waitpidでのハングはタイムアウトを設定していて、
https://httpd.apache.org/docs/2.4/ja/mod/core.html#timeout
を参考にしました、apacheと同じように504を返すのと、Connectionは切らない方向にしました。

# 受け入れ条件
コード、動作確認

動作ですが、
apacheの方だと、

```
curl -v localhost:5000/cgi-bin/post_test.cgi 
```

でタイムアウトが見れます、ヘッダなしの方は適当にcgiファイルを書き換える必要があります。

webservの場合は、あらかじめhttp_response.hppのkCgiTimeoutを1に設定した後、
```
./webserv test/confs/test.conf &
curl localhost:8082/cgi-bin/no_header.cgi    
curl localhost:8082/cgi-bin/timeout.cgi    
```
で確認ができます。