### PR TITLE
content_lengthがゼロのときヘッダの読み込みをスキップする

### DIFF
--- a/srcs/server/client_socket.cpp
+++ b/srcs/server/client_socket.cpp
@@ -256,8 +256,7 @@ int ClientSocket::EventHandler(bool is_readable, bool is_writable,
         else
           ChangeStatus(ClientSocket::WAIT_BODY);
       } else {
-        std::cout << "Unexpected Header" << std::endl;
-        ChangeStatus(ClientSocket::WAIT_CLOSE);
+        ChangeStatus(ClientSocket::CREATE_RESPONSE);
       }
     } else {
       ChangeStatus(ClientSocket::CREATE_RESPONSE);


### PR DESCRIPTION
# 概要

issueの対応ありがとうございました。content_lengthが不正の時もclient_max_bodyはのエラーが確認できました。
ただ例えば、本来GETするところをPOSTする
```
./webserv test/conf/test.conf
curl localhost:8080/ -X POST
```
などとした場合、empty responseが返ってきてしまいます。
本来であればstatus code 200とファイルの内容が欲しいです

# 受け入れ条件

コード確認、動作確認
僕が考慮できていないケースがある可能性があるので、何かこうした理由があれば教えていただきたいです。

