### PR TITLE
fix: location header by adding port number

### DIFF
--- a/srcs/response/http_response.cpp
+++ b/srcs/response/http_response.cpp
@@ -320,13 +320,15 @@ void HttpResponse::MakeHeaderRedirection() {
   oss_content_type << "Content-Type: text/html\r\n";
   oss_content_length << "Content-Length: " << body_len_ << "\r\n";
   if (status_code_ == kStatusCodeMovedPermanently) {
-    oss_location << "Location: http://" << client_info_.hostname_;
+    oss_location << "Location: http://" << client_info_.hostname_ << ":"
+                 << http_request_.host_port_;
     std::string requested_file_path_short_ =
         requested_file_path_.substr(location_config_->root_.length());
     oss_location << requested_file_path_short_ << "\r\n";
   } else {
     if (requested_file_path_.find("http://") != 0) {
-      oss_location << "Location: http://" << client_info_.hostname_;
+      oss_location << "Location: http://" << client_info_.hostname_ << ":"
+                   << http_request_.host_port_;
     } else {
       oss_location << "Location: ";
     }

--- a/srcs/server/http_request.hpp
+++ b/srcs/server/http_request.hpp
@@ -42,6 +42,7 @@ class HttpRequest {
   std::string query_string_;
   std::string version_;    // 0以外の数字から始まる文字列
   std::string host_name_;  // Host: からポート番号を取り除いたもの
+  std::string host_port_;  // Host: で指定されたポート番号
   std::string content_type_;
   size_t content_length_;
   std::string body_;

--- a/srcs/server/http_request_parser.cpp
+++ b/srcs/server/http_request_parser.cpp
@@ -148,10 +148,13 @@ int HttpRequestParser::ParseHeader(const std::string& recv_msg,
     req->is_bad_request_ = true;
   } else {  // separate host -> name:port
     pos = host.find(":");
-    if (pos == std::string::npos)
+    if (pos == std::string::npos) {
       req->host_name_ = host;
-    else
+      req->host_port_ = "80";
+    } else {
       req->host_name_ = host.substr(0, pos);
+      req->host_port_ = host.substr(pos + 1);
+    }
   }
   req->content_type_ = req->header_fields_["content-type"];
   std::stringstream sstream(req->header_fields_["content-length"]);


### PR DESCRIPTION
Redirectのときのヘッダーを修正しました。
./webserv confs/test.confで立ち上げたあとに、http://localhost:8080/dir_onで正しく動くと思います。
修正に際して、以前削除してもらっていた、Host名のコロンのあとのポート番号を復活させる必要が出てきてしまったので、HttpRequestとリクエストパーサーをちょっといじっています。
為念、ご確認ください。