### PR TITLE
正しく切断されないバグの修正

### DIFF
--- a/review.html
+++ b/review.html
@@ -180,7 +180,7 @@
 		<tr>
 			<td>ひとりのユーザがインターバルを置かずに<br>1024回リクエストを送る</td>
 			<td>% ./webserv confs/test.conf</td>
-			<td>% siege -r 1024 -c 1 -b 127.0.0.1:8080</td>
+			<td>% siege -r 1024 -c 1 -b 127.0.0.1:8080/empty.html</td>
 		</tr>
 		<tr>
 			<td>メモリリークがないか確認する</td>

--- a/review.html
+++ b/review.html
@@ -95,7 +95,7 @@
 			<td>% curl -v -X DELETE  http://localhost:8080/hoge.html</td>
 		</tr>
 		<tr>
-			<td>UNKNOWNリクエスト → 405</td>
+			<td>UNKNOWNリクエスト → 501</td>
 			<td>% ./webserv confs/test.conf</td>
 			<td>% curl -v -X UNKNOWN  http://localhost:8080/</td>
 		</tr>

--- a/srcs/server/server.cpp
+++ b/srcs/server/server.cpp
@@ -165,9 +165,10 @@ void Server::Run() {
       if (it->EventHandler(FD_ISSET(it->GetFd(), &r_fds),
                            FD_ISSET(it->GetFd(), &w_fds), config_)) {
         it = clients_.erase(it);
-        continue;
+      } else {
+        ++it;
       }
-      ++it;
+      usleep(500);
     }
 #ifdef LEAKS
     if (b_exit) break;


### PR DESCRIPTION
bad request(400)、もしくは切断命令(505かrequestでConnection:closeなど)の時に正しく切断できないバグを修正しました。

■背景
・400もしくは505の時にbad_requestのフラグが立つ時に設定していたが、大きなファイルの送信でsendを複数回行う対応の際、切断ができなくなるバグが含まれていた。

■変更内容
bad_requestであっても、正しくsendが完了した後、切断処理を行うように修正した。

■確認方法
・負荷テストで100ユーザからリクエストを発生させて、1分間、正常に200を返せることを確認。
siege停止後のAvailabilityも100.0%であることを確認。
siege -r 1024 -c 100 -b 127.0.0.1:8080/empty.html 
・telnet で、400または505を発生させたときに切断されることを確認。
・index-upload.html で大きなサイズの画像も表示できることを確認。

■その他の変更内容
・レビュー用ページで、Statusコードの誤りを修正
・負荷テスト用の空ファイルを追加
・recv,sendのシステムエラーはcerrに出力するように変更

変更点に疑問などありましたらコメントをお願いします！