### PR TITLE
fix: selectごとに1回のrecv,sendのみ呼ぶように変更

### DIFF
--- a/srcs/server/client_socket.cpp
+++ b/srcs/server/client_socket.cpp
@@ -158,6 +158,8 @@ int ClientSocket::EventHandler(bool is_readable, bool is_writable,
     if (is_readable && ReceiveHeader()) {
       ChangeStatus(ClientSocket::WAIT_CLOSE);
     }
+    is_readable = false;
+    is_writable = false;
   }
   if (status_ == ClientSocket::PARSE_HEADER) {
     HttpRequestParser::ParseHeader(recv_str_, &request_);
@@ -197,6 +199,8 @@ int ClientSocket::EventHandler(bool is_readable, bool is_writable,
     if (is_readable && ReceiveBody()) {
       ChangeStatus(ClientSocket::WAIT_CLOSE);
     }
+    is_readable = false;
+    is_writable = false;
   }
   if (status_ == ClientSocket::CREATE_RESPONSE) {
     const ServerConfig *sc = config.SelectServerConfig(


### PR DESCRIPTION
recv,sendを連続で実行するのを防ぐため、recv実行後は is_readable, is_writable のフラグを下ろし、EventHandler呼び出しにつきrecv,sendを1回のみ実行されるようにした。