### PR TITLE
fix: SIGPIPEでプログラム終了するのを回避する

### DIFF
--- a/srcs/server/client_socket.cpp
+++ b/srcs/server/client_socket.cpp
@@ -236,8 +236,12 @@ int ClientSocket::EventHandler(bool is_readable, bool is_writable,
     ChangeStatus(ClientSocket::WAIT_CLOSE);
   }
   if (status_ == ClientSocket::WAIT_CLOSE) {
-    std::cout << "Disconnect descriptor:" << fd_ << ".\n";
-    close(fd_);
+    if (0 == close(fd_)) {
+      std::cout << "Disconnect descriptor:" << fd_ << ".\n";
+    } else {
+      std::cerr << COLOR_RED "[system error] " COLOR_OFF << "close error"
+                << std::endl;
+    }
     return 1;
   }
   return 0;

--- a/srcs/server/server.cpp
+++ b/srcs/server/server.cpp
@@ -100,7 +100,6 @@ int Server::AcceptNewClient(const fd_set &fds) {
   for (; it != sockets_.end(); ++it) {
     if (FD_ISSET(it->GetListenFd(), &fds)) {
       int connfd = accept(it->GetListenFd(), (struct sockaddr *)&sin, &len);
-      // TODO 最大接続数を10にした理由を課題分やレビューから見つける。
       if (clients_.size() < kMaxSessionNum) {
         clients_.push_back(ClientSocket(connfd, &(*it), sin));
         clients_.back().Init();
@@ -130,6 +129,8 @@ void Server::Run() {
     std::exit(EXIT_FAILURE);
   }
 #endif
+  signal(SIGPIPE, SIG_IGN);
+
   /***
    * サーバーソケットを生成
    */

--- a/srcs/server/server.cpp
+++ b/srcs/server/server.cpp
@@ -129,7 +129,9 @@ void Server::Run() {
     std::exit(EXIT_FAILURE);
   }
 #endif
-  signal(SIGPIPE, SIG_IGN);
+  if (signal(SIGPIPE, SIG_IGN) == SIG_ERR) {
+    std::exit(EXIT_FAILURE);
+  }
 
   /***
    * サーバーソケットを生成


### PR DESCRIPTION
コネクションが切れたソケットにsend/recvするとSIGPIPEが発生する。
起動時に無視するように設定することで、プログラムが落ちずにsystem error となるようにした。